### PR TITLE
Add basic auth on redirects

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -57,6 +57,13 @@ func (p Plugin) Exec() error {
 				InsecureSkipVerify: p.Config.SkipVerify,
 			},
 		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if p.Config.Username != "" && p.Config.Password != "" {
+				req.SetBasicAuth(p.Config.Username, p.Config.Password)
+			}
+
+			return nil
+		},
 	}
 
 	req, err := http.NewRequest(


### PR DESCRIPTION
Append the basic authentication if the download server redirects to a different site, otherwise the basic authentication gets lost.