### PR TITLE
added ability to specify a authorization header

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,11 @@ func main() {
 			EnvVar: "PLUGIN_DESTINATION",
 		},
 		cli.StringFlag{
+			Name:   "authorization",
+			Usage:  "value to send in the authorization header",
+			EnvVar: "PLUGIN_AUTHORIZATION,DOWNLOAD_AUTHORIZATION",
+		},
+		cli.StringFlag{
 			Name:   "username",
 			Usage:  "username for basic auth",
 			EnvVar: "PLUGIN_USERNAME,DOWNLOAD_USERNAME",
@@ -66,13 +71,14 @@ func main() {
 func run(c *cli.Context) error {
 	plugin := Plugin{
 		Config: Config{
-			Source:      c.String("source"),
-			Destination: c.String("destination"),
-			Username:    c.String("username"),
-			Password:    c.String("password"),
-			SkipVerify:  c.Bool("skip-verify"),
-			MD5:         c.String("md5-checksum"),
-			SHA265:      c.String("sha265-checksum"),
+			Source:        c.String("source"),
+			Destination:   c.String("destination"),
+			Authorization: c.String("authorization"),
+			Username:      c.String("username"),
+			Password:      c.String("password"),
+			SkipVerify:    c.Bool("skip-verify"),
+			MD5:           c.String("md5-checksum"),
+			SHA265:        c.String("sha265-checksum"),
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -19,13 +19,14 @@ import (
 
 type (
 	Config struct {
-		Source      string
-		Destination string
-		Username    string
-		Password    string
-		SkipVerify  bool
-		MD5         string
-		SHA265      string
+		Source        string
+		Destination   string
+		Authorization string
+		Username      string
+		Password      string
+		SkipVerify    bool
+		MD5           string
+		SHA265        string
 	}
 
 	Plugin struct {
@@ -61,7 +62,9 @@ func (p Plugin) Exec() error {
 			if p.Config.Username != "" && p.Config.Password != "" {
 				req.SetBasicAuth(p.Config.Username, p.Config.Password)
 			}
-
+			if p.Config.Authorization != "" {
+				req.Header.Add("Authorization", p.Config.Authorization)
+			}
 			return nil
 		},
 	}
@@ -78,6 +81,10 @@ func (p Plugin) Exec() error {
 
 	if p.Config.Username != "" && p.Config.Password != "" {
 		req.SetBasicAuth(p.Config.Username, p.Config.Password)
+	}
+
+	if p.Config.Authorization != "" {
+		req.Header.Add("Authorization", p.Config.Authorization)
 	}
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
When wanting to download from a private resource, we sometimes need a ApiKey / Bearer Token - this options allows to specify the Keys